### PR TITLE
Fixed "tag only" case

### DIFF
--- a/update.elv
+++ b/update.elv
@@ -33,9 +33,14 @@ use re
 short-hash-length = 7
 update-message = 'Elvish Upgrade Available - update:build-HEAD'
 
-fn current-commit {
-  # Get the commit from the currently installed Elvish binary
-  put (or (re:find ".*-.*-g(.*)" (elvish -buildinfo -json | from-json)[version])[groups][1][text] unknown)
+fn current-commit-or-tag {
+  # Get the tag and commit from the currently installed Elvish binary
+  tag commit = (re:find '^(.*?)(?:-\d+-g(.*))?$' (elvish -buildinfo -json | from-json)[version])[groups][1 2][text]
+  if (not-eq $commit '') {
+    put $commit
+  } else {
+    put $tag
+  }
 }
 
 fn last-modified {
@@ -47,7 +52,7 @@ fn last-modified {
   }
 }
 
-fn check-commit [&commit=(current-commit) &verbose=$false]{
+fn check-commit [&commit=(current-commit-or-tag) &verbose=$false]{
   if (eq $commit unknown) {
     echo (styled "Your elvish does not report a version number in elvish -buildinfo" red)
   } else {
@@ -79,7 +84,7 @@ fn check-commit [&commit=(current-commit) &verbose=$false]{
   }
 }
 
-fn async-check-commit [&commit=(current-commit) &verbose=$false]{
+fn async-check-commit [&commit=(current-commit-or-tag) &verbose=$false]{
   check-commit &commit=$commit &verbose=$verbose &
 }
 

--- a/update.elv
+++ b/update.elv
@@ -106,8 +106,12 @@ fn build-HEAD {
       echo (styled "Unable to query github to determine number of commits since last tag" red)
     }
     total-commits = $from-master[total_commits]
-    short-last-commit = (re:find "^.{"$short-hash-length"}" $from-master[commits][-1][sha])[text]
-    version = $tag"-"$from-master[total_commits]"-g"$short-last-commit
+    commit-version = ""
+    if (> $total-commits 0) {
+      short-last-commit = (re:find "^.{"$short-hash-length"}" $from-master[commits][-1][sha])[text]
+      commit-version = "-"$from-master[total_commits]"-g"$short-last-commit
+    }
+    version = $tag$commit-version
 
     error = ?(
       go get \


### PR DESCRIPTION
Fixed the case when there are no commits since the last tag (i.e. when total-commits is 0), to produce the same version as the Elvish Makefile does with `git describe --tags --always --dirty=-dirty`.