### PR TITLE
Fix SHA values printed by update &verbose

### DIFF
--- a/update.elv
+++ b/update.elv
@@ -76,7 +76,7 @@ fn check-commit [&commit=(current-commit-or-tag) &verbose=$false]{
         echo (styled $update-message yellow)
         if $verbose {
           for commit $json[commits] {
-            echo (styled $commit[commit][tree][sha][0:$short-hash-length] magenta)': '(styled $commit[commit][message] green)
+            echo (styled $commit[sha][0:$short-hash-length] magenta)': '(styled $commit[commit][message] green)
           }
         }
       }


### PR DESCRIPTION
It was printing the tree SHAs instead of the commit SHAs. Now they match with the output from git log.