### PR TITLE
Remove -u flag from go get command

### DIFF
--- a/update.elv
+++ b/update.elv
@@ -132,7 +132,7 @@ fn build-HEAD [&silent=$false]{
       go get \
       -trimpath \
       -ldflags "-X github.com/elves/elvish/buildinfo.Version="$version" -X github.com/elves/elvish/buildinfo.Reproducible=true" \
-      -u github.com/elves/elvish
+      github.com/elves/elvish
     )
     if $build_ok {
       if (not $silent) {


### PR DESCRIPTION
The -u flag results sometimes in go.mod and go.sum being left modified after build, which breaks future runs unless one manually cleans up the directory (the checkout fails due to locally-modified files). I think it might be best to omit it.