### PR TITLE
Avoid hardcoding binary paths

### DIFF
--- a/update.elv
+++ b/update.elv
@@ -47,9 +47,9 @@ fn current-commit-or-tag {
 fn last-modified {
   platform = (uname)
   if (eq $platform "Darwin") {
-    put (/bin/date -u -j -r (/usr/bin/stat -f%B (which elvish)) +"%a, %d %b %Y %H:%M:%S GMT")
+    put (/usr/bin/env date -u -j -r (/usr/bin/env stat -f%B (which elvish)) +"%a, %d %b %Y %H:%M:%S GMT")
   } elif (eq $platform "Linux") {
-    put (/bin/date -u -d (/usr/bin/stat -c%y (which elvish)) +"%a, %d %b %Y %H:%M:%S GMT")
+    put (/usr/bin/env date -u -d (/usr/bin/env stat -c%y (which elvish)) +"%a, %d %b %Y %H:%M:%S GMT")
   }
 }
 


### PR DESCRIPTION
Hardcoded binary paths fail on NixOS and similar. Using `/usr/bin/env` is more reliable.

Signed-off-by: SitiSchu <admin@sitischu.com>