### PR TITLE
Use macOS native date and stat commands

### DIFF
--- a/update.elv
+++ b/update.elv
@@ -47,7 +47,7 @@ fn current-commit-or-tag {
 fn last-modified {
   platform = (uname)
   if (eq $platform "Darwin") {
-    put (/usr/bin/env date -u -j -r (/usr/bin/env stat -f%B (which elvish)) +"%a, %d %b %Y %H:%M:%S GMT")
+    put (/bin/date -u -j -r (/usr/bin/stat -f%B (which elvish)) +"%a, %d %b %Y %H:%M:%S GMT")
   } elif (eq $platform "Linux") {
     put (/usr/bin/env date -u -d (/usr/bin/env stat -c%y (which elvish)) +"%a, %d %b %Y %H:%M:%S GMT")
   }


### PR DESCRIPTION
When on Darwin, use the native date and stat commands instead of running
them through env. This fixes the case where other versions (e.g. GNU date
and stat) are the default in the path, since they do not understand some
Mac-specific options.