### PR TITLE
fix: use v-tag

### DIFF
--- a/update.elv
+++ b/update.elv
@@ -41,7 +41,7 @@ fn current-commit-or-tag {
   if (not-eq $commit '') {
     put $commit
   } else {
-    put $tag
+    put "v"$tag
   }
 }
 


### PR DESCRIPTION
It seems that `https://api.github.com/repos/elves/elvish/compare/0.17.0...master` doesn't work, while `https://api.github.com/repos/elves/elvish/compare/v0.17.0...master` works. 